### PR TITLE
Fix .envrc flake outputs for codex-rs and codex-cli directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,9 +715,9 @@ If you have direnv installed, you can use the following `.envrc` to automaticall
 
 ```bash
 cd codex-rs
-echo "use flake ../flake.nix#codex-cli" >> .envrc && direnv allow
-cd codex-cli
 echo "use flake ../flake.nix#codex-rs" >> .envrc && direnv allow
+cd codex-cli
+echo "use flake ../flake.nix#codex-cli" >> .envrc && direnv allow
 ```
 
 ---


### PR DESCRIPTION
This PR corrects the use flake directives in the .envrc examples to reference the matching flake outputs for each directory. Previously, the examples inadvertently swapped the codex-rs and codex-cli outputs. 

No functional code changes, this is documentation-only update